### PR TITLE
Fixed next button onclick navigation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -341,7 +341,7 @@ class VueZoomImg {
       iconName === 'close'
         ? this.closePreview()
         : this.allInstances
-          ? this.nextPreviousImage(iconName === 'navigate_next')
+          ? this.nextPreviousImage(iconName === 'next')
           : null
     }
     button.classList.add('maz-zoom-btn')


### PR DESCRIPTION
The next button is created with `iconName` of `next`,  but the `nextPreviousImage` method call in the `onClick` handler checks if the value of `iconName` is `navigate_next`.